### PR TITLE
cmake: tweaking install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,30 +107,20 @@ if(pfasst_BUILD_TESTS)
 endif()
 message(STATUS "********************************************************************************")
 
-message(STATUS "C++ Compiler: ${CMAKE_CXX_COMPILER}")
-message(STATUS "C++ Compiler ID: ${CMAKE_CXX_COMPILER_ID}")
-message(STATUS "C++ Compiler Names: ${CMAKE_CXX_COMPILER_NAMES}")
-message(STATUS "C++ Compiler Version: ${CMAKE_CXX_COMPILER_VERSION}")
-message(STATUS "C++ Flags: ${CMAKE_CXX_FLAGS}")
-message(STATUS "C++ link flags: ${CMAKE_CXX_LINK_FLAGS}")
+message(STATUS "Creating 'install' target for header files")
+message(STATUS "  will install them to '${CMAKE_INSTALL_PREFIX}/include/pfasst'")
+install(DIRECTORY include/pfasst/
+  DESTINATION include/pfasst
+  FILES_MATCHING PATTERN "*.hpp"
+)
 
-INSTALL(FILES
-  include/pfasst/controller.hpp
-  include/pfasst/globals.hpp
-  include/pfasst/interfaces.hpp
-  include/pfasst/mlsdc.hpp
-  include/pfasst/mpi_communicator.hpp
-  include/pfasst/pfasst.hpp
-  include/pfasst/quadrature.hpp
-  include/pfasst/sdc.hpp
-  DESTINATION include/pfasst)
-
-INSTALL(FILES
-  include/pfasst/encap/automagic.hpp
-  include/pfasst/encap/encapsulation.hpp
-  include/pfasst/encap/encap_sweeper.hpp
-  include/pfasst/encap/imex_sweeper.hpp
-  include/pfasst/encap/mpi_vector.hpp
-  include/pfasst/encap/poly_interp.hpp
-  include/pfasst/encap/vector.hpp
-  DESTINATION include/pfasst/encap)
+message(STATUS "********************************************************************************")
+if(${CMAKE_VERBOSE_MAKEFILE})
+  message(STATUS "C++ Compiler: ${CMAKE_CXX_COMPILER}")
+  message(STATUS "C++ Compiler ID: ${CMAKE_CXX_COMPILER_ID}")
+  message(STATUS "C++ Compiler Names: ${CMAKE_CXX_COMPILER_NAMES}")
+  message(STATUS "C++ Compiler Version: ${CMAKE_CXX_COMPILER_VERSION}")
+  message(STATUS "C++ Flags: ${CMAKE_CXX_FLAGS}")
+  message(STATUS "C++ link flags: ${CMAKE_CXX_LINK_FLAGS}")
+  message(STATUS "********************************************************************************")
+endif()


### PR DESCRIPTION
Using the `DIRECTORY` version of CMake's `install` command catches all header files and we don't have to manually add new header files in the future.
